### PR TITLE
Fix error message of nested validator

### DIFF
--- a/src/validation/drivers/helpers/either.ts
+++ b/src/validation/drivers/helpers/either.ts
@@ -45,9 +45,6 @@ export function either<I, O1, O2, O3, O4, O5>(
                     return await validator(i)
                 } catch (e) {
                     errors.push(e)
-                    if (e.fieldPath) {
-                        throw e
-                    }
                 }
             }
         }
@@ -61,6 +58,9 @@ export function either<I, O1, O2, O3, O4, O5>(
         for (let error of errors) {
             if (error instanceof ValidationError) {
                 failedConstraints.push(error.constraintName)
+                if (error.fieldPath) {
+                    throw error
+                }
 
                 if (error.internalMessage) {
                     failedInternalMessages.push(error.internalMessage)

--- a/src/validation/drivers/helpers/either.ts
+++ b/src/validation/drivers/helpers/either.ts
@@ -45,6 +45,9 @@ export function either<I, O1, O2, O3, O4, O5>(
                     return await validator(i)
                 } catch (e) {
                     errors.push(e)
+                    if (e.fieldPath) {
+                        throw e
+                    }
                 }
             }
         }


### PR DESCRIPTION
e.g. 

```js
const myValidator = isObject({
  a:  either(
    isObject({
      b: either(isUndefined, isNumber)
    }) 
    isObject({
      c: either(isUndefined, isNumber)
    })
  )
})
```
Running with 

```js
myValidator({
  a: {b: 'asdf', c: 'asdf'}
})
```

Current behaviour

```
{fieldPath: 'a', constraint: "EITHER(EITHER(IS_UNDEFINED, IS_NUMBER),EITHER(IS_UNDEFINED, IS_NUMBER))"}
```

Expected behaviour

```
{fieldPath: 'a', constraint: "EITHER(IS_OBJECT('b',EITHER(IS_UNDEFINED, IS_NUMBER)),IS_OBJECT('c',EITHER(IS_UNDEFINED, IS_NUMBER)))" }
EITHER(IS_UNDEFINED, IS_NUMBER),EITHER(IS_UNDEFINED, IS_NUMBER))'}
```